### PR TITLE
Don't force string_tracker to be a static library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(stringpool)
 add_library(string_pool INTERFACE)
 target_include_directories(string_pool INTERFACE include)
 
-add_library(string_tracker STATIC
+add_library(string_tracker
 	src/string_tracker.cpp
 )
 target_link_libraries(string_tracker string_pool)


### PR DESCRIPTION
CMake defaults to building static libraries anyway. This way, the user can choose to build shared libraries by configuring with `-DBUILD_SHARED_LIBS=ON`.